### PR TITLE
feat: modernize and deploy

### DIFF
--- a/bucket.tf
+++ b/bucket.tf
@@ -1,3 +1,29 @@
+locals {
+  bucket_name_default = "${var.organization}-${var.environment}-${var.name}"
+  bucket_name         = var.bucket_name == "" ? local.bucket_name_default : var.bucket_name
+}
+
+resource "aws_s3_bucket" "web" {
+  bucket        = local.bucket_name
+  force_destroy = var.bucket_force_destroy
+
+  tags = merge(
+    {
+      "Name" = local.bucket_name
+    },
+    {
+      "Environment" = var.environment
+    },
+    var.tags,
+  )
+}
+
+output "bucket_name" {
+  value = local.bucket_name
+}
+
+# Read the policy description for cloudfront access
+
 data "aws_iam_policy_document" "s3_policy" {
   statement {
     actions   = ["s3:GetObject"]
@@ -10,46 +36,56 @@ data "aws_iam_policy_document" "s3_policy" {
   }
 }
 
-data "aws_caller_identity" "current" {
-}
-
-locals {
-  bucket_name_default = "${data.aws_caller_identity.current.account_id}-${var.environment}-${var.name}"
-  bucket_name         = var.bucket_name == "" ? local.bucket_name_default : var.bucket_name
-}
-
 resource "aws_s3_bucket_policy" "web" {
   bucket = aws_s3_bucket.web.id
   policy = data.aws_iam_policy_document.s3_policy.json
 }
 
-resource "aws_s3_bucket" "web" {
-  bucket        = local.bucket_name
-  acl           = var.bucket_acl
-  force_destroy = var.bucket_force_destroy
+# Private access policies
 
-  tags = merge(
-    {
-      "Name" = format("%s", "Bucket for CloudFront ${var.environment}")
-    },
-    {
-      "Environment" = format("%s", var.environment)
-    },
-    var.tags,
-  )
-
-  versioning {
-    enabled = var.bucket_versioning
+resource "aws_s3_bucket_ownership_controls" "web" {
+  bucket = aws_s3_bucket.web.id
+  rule {
+    object_ownership = "BucketOwnerPreferred"
   }
+}
 
-  lifecycle_rule {
-    id      = "expire-old-versions"
-    prefix  = "*"
-    enabled = var.bucket_versioning
+resource "aws_s3_bucket_acl" "web" {
+  depends_on = [
+    aws_s3_bucket_ownership_controls.web
+  ]
 
-    noncurrent_version_expiration {
-      days = 7
+  bucket = aws_s3_bucket.web.id
+  acl    = var.bucket_acl
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "web" {
+  bucket = aws_s3_bucket.web.id
+
+  rule {
+    id     = "${local.bucket_name}-lifecycle"
+    status = "Enabled"
+
+    abort_incomplete_multipart_upload {
+      days_after_initiation = 7
+    }
+
+    noncurrent_version_transition {
+      noncurrent_days = 30
+      storage_class   = "STANDARD_IA"
+    }
+
+    noncurrent_version_transition {
+      noncurrent_days = 60
+      storage_class   = "GLACIER"
     }
   }
 }
 
+resource "aws_s3_bucket_versioning" "web" {
+  bucket = aws_s3_bucket.web.id
+
+  versioning_configuration {
+    status = "Enabled"
+  }
+}

--- a/bucket.tf
+++ b/bucket.tf
@@ -18,10 +18,6 @@ resource "aws_s3_bucket" "web" {
   )
 }
 
-output "bucket_name" {
-  value = local.bucket_name
-}
-
 # Read the policy description for cloudfront access
 
 data "aws_iam_policy_document" "s3_policy" {

--- a/cloudfront.tf
+++ b/cloudfront.tf
@@ -2,10 +2,6 @@ resource "aws_cloudfront_origin_access_identity" "origin_access_identity" {
   comment = "${var.environment}-cloudfront-access-identity"
 }
 
-locals {
-  dns_alias = "${local.subdomain}.${var.dns_name}"
-}
-
 resource "aws_cloudfront_distribution" "web" {
   origin {
     domain_name = aws_s3_bucket.web.bucket_regional_domain_name
@@ -26,7 +22,7 @@ resource "aws_cloudfront_distribution" "web" {
   enabled             = true
   is_ipv6_enabled     = true
   default_root_object = var.default_root_object
-  aliases             = compact([var.enable_route53_record ? local.dns_alias : ""])
+  aliases             = compact([var.enable_route53_record ? var.dns_name : ""])
 
   default_cache_behavior {
     allowed_methods  = var.default_cache_behavior_allowed_methods

--- a/cloudfront.tf
+++ b/cloudfront.tf
@@ -23,12 +23,14 @@ resource "aws_cloudfront_distribution" "web" {
   is_ipv6_enabled     = true
   default_root_object = var.default_root_object
   aliases             = compact([var.enable_route53_record ? var.dns_name : ""])
+  comment             = local.bucket_name
 
   default_cache_behavior {
-    allowed_methods  = var.default_cache_behavior_allowed_methods
-    cached_methods   = var.default_cache_behavior_cached_methods
-    compress         = var.default_cache_behavior_compress
-    target_origin_id = "${var.environment}-${var.name}"
+    allowed_methods    = var.default_cache_behavior_allowed_methods
+    cached_methods     = var.default_cache_behavior_cached_methods
+    compress           = var.default_cache_behavior_compress
+    target_origin_id   = "${var.environment}-${var.name}"
+    trusted_key_groups = var.default_cache_trusted_key_groups
 
     forwarded_values {
       query_string = false

--- a/route53.tf
+++ b/route53.tf
@@ -1,17 +1,13 @@
-locals {
-  subdomain = var.subdomain == "" ? var.environment : var.subdomain
-}
-
 data "aws_route53_zone" "zone" {
   count = var.enable_route53_record ? 1 : 0
-  name  = var.dns_name
+  name  = var.dns_zone_name
 }
 
 resource "aws_route53_record" "web" {
   count = var.enable_route53_record ? 1 : 0
 
   zone_id = data.aws_route53_zone.zone[0].id
-  name    = "${local.subdomain}.${data.aws_route53_zone.zone[0].name}"
+  name    = var.dns_name
 
   type = "A"
 

--- a/variables.tf
+++ b/variables.tf
@@ -24,8 +24,8 @@ variable "dns_name" {
   default     = ""
 }
 
-variable "subdomain" {
-  description = "By default the environment name is used as subdomain, set this variable to use a custom subdomain. No dots are supported yet."
+variable "dns_zone_name" {
+  description = "Zone in which to create route53 records"
   type        = string
   default     = ""
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,3 +1,8 @@
+variable "organization" {
+  description = "Org name for humans."
+  type        = string
+}
+
 variable "environment" {
   description = "Logical name of the environment."
   type        = string

--- a/variables.tf
+++ b/variables.tf
@@ -96,9 +96,15 @@ variable "default_cache_behavior_compress" {
   default     = false
 }
 
+variable "default_cache_trusted_key_groups" {
+  description = "Trusted key groups for URL signing"
+  type        = list(string)
+  default     = []
+}
+
 variable "restrictions_geo_restriction_location" {
   description = "The ISO 3166-1-alpha-2 codes for which you want CloudFront either to distribute your content (whitelist) or not distribute your content (blacklist)."
-  type        = list
+  type        = list(any)
   default     = []
 }
 
@@ -137,4 +143,3 @@ variable "custom_error_response" {
   type        = list(map(string))
   default     = []
 }
-


### PR DESCRIPTION
I found this module for pairing a private s3 bucket and a cloudfront proxy, which seems to do more or less the right thing.

- The module was a little quirky about composing DNS names, it now expects each name passed in explicitly
- AWS has changed how s3 buckets are configured, so set them up the new way
- The module was not expecting a `trusted_key_group` it can now be configured with some which will also cause the default behavior to deny access unless a signed URL is provided