### PR TITLE
feat: 🔒 add WAF ARN to CloudFront distro

### DIFF
--- a/cloudfront.tf
+++ b/cloudfront.tf
@@ -19,6 +19,8 @@ resource "aws_cloudfront_distribution" "web" {
     }
   }
 
+  web_acl_id = var.aws_wafv2_web_acl_arn
+
   enabled             = true
   is_ipv6_enabled     = true
   default_root_object = var.default_root_object

--- a/variables.tf
+++ b/variables.tf
@@ -147,3 +147,9 @@ variable "custom_error_response" {
   type        = list(map(string))
   default     = []
 }
+
+variable "aws_wafv2_web_acl_arn" {
+  description = "ARN of the WAFv2 webACL to be used for this CF distribution"
+  type = string
+  # CF distros should have a WAF for compliance purposes, so require a value
+}


### PR DESCRIPTION
allow reuse of the AWS WAF (v2) webACL that we already have for the other CloudFront distros, in the distro managed by this module too.